### PR TITLE
Append build to OUT_DIR in example

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,8 +20,7 @@
 //! use std::path::PathBuf;
 //!
 //! fn main() {
-//!     let build_path = PathBuf::from(env::var("OUT_DIR").unwrap());
-//!     build_path.join("build");
+//!     let build_path = PathBuf::from(env::var("OUT_DIR").unwrap()).join("build");
 //!     let build_path = build_path.to_str().unwrap();
 //!
 //!     println!("cargo:rustc-link-lib=squid");


### PR DESCRIPTION
[`join`](https://doc.rust-lang.org/std/path/struct.PathBuf.html#method.join) doesn't mutate the `PathBuf`, it returns a new `PathBuf` with the fragment appended. This change chains the call so that the build artefacts from meson are put in the sub dir instead of in `OUT_DIR`.